### PR TITLE
Soliciting TSC vote for OpenTofu booth at KubeCon NA 2026

### DIFF
--- a/TSC/2026-03-31_AGENDA.md
+++ b/TSC/2026-03-31_AGENDA.md
@@ -1,4 +1,9 @@
 # Topics to discuss
 
 - Decision on whether to lock and shut down the deprecated `opentofucommunity.slack.com` Slack workspace.
+<<<<<<< HEAD
 - Decision on the addition of Yaron Yarimi (yaron.yarimi@env0.com) as a member of the TSC, alongside Arel resigning from the TSC
+=======
+- KubeCon NA 2026 Project Pavilion booth for OpenTofu: should we have one?
+  - If affirmative, actions items to delegate include, but are not limited to: coordinating with CNCF, figuring out a schedule for people manning the booth.
+>>>>>>> 9269dda (Soliciting TSC vote for OpenTofu booth at KubeCon NA 2026)


### PR DESCRIPTION
KubeCon Europe 2026 in Amsterdam is just winding down, and one of the things I would have changed would be having a booth at the Project Pavilion. I am a maintainer, and I will be at KubeCon in Salt Lake City this year. I would gladly volunteer to man the booth, but there needs to be coordination in terms of booking the booth, who else will be there to aid in working the booth, and coming up with what we want to present or display at the booth. All of this, of course, is contingent on an affirmative vote for having a booth in this upcoming convention.