### PR TITLE
repos: enumerate and classify supervised repositories

### DIFF
--- a/REPOS.md
+++ b/REPOS.md
@@ -4,22 +4,26 @@ There are many repositories in the `opentofu` GitHub organization, and it can be
 
 ## Repository classification
 
-OpenTofu has uncommon intellectual property risks. Because of these challenges, OpenTofu's repositories are partitioned into three policy designations, categorized by the level of legal scrutiny:
+OpenTofu has uncommon intellectual property risks (see the [note on copyright](https://github.com/opentofu/opentofu/blob/8541e02cc6fd0bb3bbcf2ec20bb440be2816dae1/contributing/DEVELOPING.md#a-note-on-copyright) in the `opentofu` repository). Because of these challenges, OpenTofu's repositories are partitioned into three policy designations, categorized by the level of legal scrutiny:
 
  - **Class A**: Any forked repository whose upstream has been updated to use an incompatible license.
- - **Class B**: Any forked repository whose upstream retains the same, open-source license. A license is considered open-source if it is one of the [mainstream licenses accepted by OSI](https://opensource.org/licenses?categories=popular-strong-community). For OpenTofu, the license is usually [MPL 2.0](https://opensource.org/license/MPL-2.0).
+ - **Class B**: Any forked repository whose upstream retains the same, open-source license. A license might be considered open-source, for example, if it is one of the [mainstream licenses accepted by OSI](https://opensource.org/licenses?categories=popular-strong-community); exceptions may be taken, though only judiciously.
  - **Class C**: Source repositories originating from the OpenTofu organization.
 
-The following are all supervised repos in the `opentofu` GitHub organization, along with their classifications:
+The following are all supervised repos in the `opentofu` GitHub organization, along with their classifications. This information should be the same as the `repos.yml` file, also located in this directory:
 
 ### Class A
  - [opentofu](https://github.com/opentofu/opentofu)
 ### Class B
+
+ > Note: Every repository currently in Class B is licensed under the [Mozilla Public License 2.0](https://opensource.org/license/MPL-2.0).
+
  - [vscode-opentofu](https://github.com/opentofu/vscode-opentofu)
  - [tofu-ls](https://github.com/opentofu/tofu-ls)
  - [hcl](https://github.com/opentofu/hcl)
  - [registry-address](https://github.com/opentofu/registry-address)
  - [setup-opentofu](https://github.com/opentofu/setup-opentofu)
+ - [tofu-exec](https://github.com/opentofu/tofu-exec)
 ### Class C
  - [registry](https://github.com/opentofu/registry)
  - [opentofu.org](https://github.com/opentofu/opentofu.org)
@@ -27,6 +31,5 @@ The following are all supervised repos in the `opentofu` GitHub organization, al
  - [opentofu-performance-testing](https://github.com/opentofu/opentofu-performance-testing)
  - [registry-ui](https://github.com/opentofu/registry-ui)
  - [opentofu-mcp-server](https://github.com/opentofu/opentofu-mcp-server)
- - [tofu-exec](https://github.com/opentofu/tofu-exec)
  - [tofudl](https://github.com/opentofu/tofudl)
- - [brand-artifacts](https://github.com/opentofu/brand-artifacts)
+

--- a/REPOS.md
+++ b/REPOS.md
@@ -1,0 +1,32 @@
+# Supervised Repositories
+
+There are many repositories in the `opentofu` GitHub organization, and it can be difficult to determine which ones are open for community contributions. Rather than leave it up to guesswork, this list is the only set of repositories for which OpenTofu's maintainers will review, accept, and merge issues and pull requests from the OpenTofu community, the open-source community, and beyond.
+
+## Repository classification
+
+OpenTofu has uncommon intellectual property risks. Because of these challenges, OpenTofu's repositories are partitioned into three policy designations, categorized by the level of legal scrutiny:
+
+ - **Class A**: Any forked repository whose upstream has been updated to use an incompatible license.
+ - **Class B**: Any forked repository whose upstream retains the same, open-source license. A license is considered open-source if it is one of the [mainstream licenses accepted by OSI](https://opensource.org/licenses?categories=popular-strong-community). For OpenTofu, the license is usually [MPL 2.0](https://opensource.org/license/MPL-2.0).
+ - **Class C**: Source repositories originating from the OpenTofu organization.
+
+The following are all supervised repos in the `opentofu` GitHub organization, along with their classifications:
+
+### Class A
+ - [opentofu](https://github.com/opentofu/opentofu)
+### Class B
+ - [vscode-opentofu](https://github.com/opentofu/vscode-opentofu)
+ - [tofu-ls](https://github.com/opentofu/tofu-ls)
+ - [hcl](https://github.com/opentofu/hcl)
+ - [registry-address](https://github.com/opentofu/registry-address)
+ - [setup-opentofu](https://github.com/opentofu/setup-opentofu)
+### Class C
+ - [registry](https://github.com/opentofu/registry)
+ - [opentofu.org](https://github.com/opentofu/opentofu.org)
+ - [org](https://github.com/opentofu/org)
+ - [opentofu-performance-testing](https://github.com/opentofu/opentofu-performance-testing)
+ - [registry-ui](https://github.com/opentofu/registry-ui)
+ - [opentofu-mcp-server](https://github.com/opentofu/opentofu-mcp-server)
+ - [tofu-exec](https://github.com/opentofu/tofu-exec)
+ - [tofudl](https://github.com/opentofu/tofudl)
+ - [brand-artifacts](https://github.com/opentofu/brand-artifacts)

--- a/REPOS.md
+++ b/REPOS.md
@@ -2,6 +2,8 @@
 
 There are many repositories in the `opentofu` GitHub organization, and it can be difficult to determine which ones are open for community contributions. Rather than leave it up to guesswork, this list is the only set of repositories for which OpenTofu's maintainers will review, accept, and merge issues and pull requests from the OpenTofu community, the open-source community, and beyond.
 
+Any repository that is not listed here is not open to community contributions. We may modify this list from time to time, adding or removing repositories as their circumstances change (e.g a new project being added, a project reaching such a maturity to accept community contributions, a project becoming archived, etc.).
+
 ## Repository classification
 
 OpenTofu has uncommon intellectual property risks (see the [note on copyright](https://github.com/opentofu/opentofu/blob/8541e02cc6fd0bb3bbcf2ec20bb440be2816dae1/contributing/DEVELOPING.md#a-note-on-copyright) in the `opentofu` repository). Because of these challenges, OpenTofu's repositories are partitioned into three policy designations, categorized by the level of legal scrutiny:

--- a/repos.yml
+++ b/repos.yml
@@ -1,0 +1,17 @@
+class_a:
+  opentofu: https://github.com/opentofu/opentofu
+class_b:
+  vscode-opentofu: https://github.com/opentofu/vscode-opentofu
+  tofu-ls: https://github.com/opentofu/tofu-ls
+  hcl: https://github.com/opentofu/hcl
+  registry-address: https://github.com/opentofu/registry-address
+  setup-opentofu: https://github.com/opentofu/setup-opentofu
+  tofu-exec: https://github.com/opentofu/tofu-exec
+class_c:
+  registry: https://github.com/opentofu/registry
+  opentofu.org: https://github.com/opentofu/opentofu.org
+  org: https://github.com/opentofu/org
+  opentofu-performance-testing: https://github.com/opentofu/opentofu-performance-testing
+  registry-ui: https://github.com/opentofu/registry-ui
+  opentofu-mcp-server: https://github.com/opentofu/opentofu-mcp-server
+  tofudl: https://github.com/opentofu/tofudl


### PR DESCRIPTION
Resolves #23 .

I've listed all repositories where maintainers will welcome community contributions. The purpose of classifications will be more clear when we next add policies around AI-generated contributions to each of those repositories.